### PR TITLE
Default

### DIFF
--- a/src/main/java/com/hhplus/clean/architecture/application/LectureFacade.java
+++ b/src/main/java/com/hhplus/clean/architecture/application/LectureFacade.java
@@ -3,6 +3,7 @@ package com.hhplus.clean.architecture.application;
 import com.hhplus.clean.architecture.domain.lecture.Lecture;
 import com.hhplus.clean.architecture.domain.lecture.LectureRegistration;
 import com.hhplus.clean.architecture.domain.lecture.LectureService;
+import com.hhplus.clean.architecture.domain.lecture.model.LectureInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -20,6 +21,10 @@ public class LectureFacade {
 
     public List<Lecture> getLectures(){
         return lectureService.getLectureList();
+    }
+
+    public LectureInfo getLectureWithSchedules(Long lectureId) {
+        return lectureService.getLectureWithSchedule(lectureId);
     }
 
 }

--- a/src/main/java/com/hhplus/clean/architecture/application/LectureFacade.java
+++ b/src/main/java/com/hhplus/clean/architecture/application/LectureFacade.java
@@ -27,4 +27,7 @@ public class LectureFacade {
         return lectureService.getLectureWithSchedule(lectureId);
     }
 
+    public List<LectureInfo> getRegisteredLectures(Long userId) {
+        return lectureService.getRegisteredLectures(userId);
+    }
 }

--- a/src/main/java/com/hhplus/clean/architecture/application/LectureFacade.java
+++ b/src/main/java/com/hhplus/clean/architecture/application/LectureFacade.java
@@ -3,7 +3,7 @@ package com.hhplus.clean.architecture.application;
 import com.hhplus.clean.architecture.domain.lecture.Lecture;
 import com.hhplus.clean.architecture.domain.lecture.LectureRegistration;
 import com.hhplus.clean.architecture.domain.lecture.LectureService;
-import com.hhplus.clean.architecture.domain.lecture.model.LectureInfo;
+import com.hhplus.clean.architecture.domain.lecture.model.LectureDetail;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -23,11 +23,11 @@ public class LectureFacade {
         return lectureService.getLectureList();
     }
 
-    public LectureInfo getLectureWithSchedules(Long lectureId) {
+    public LectureDetail getLectureWithSchedules(Long lectureId) {
         return lectureService.getLectureWithSchedule(lectureId);
     }
 
-    public List<LectureInfo> getRegisteredLectures(Long userId) {
+    public List<LectureDetail> getRegisteredLectures(Long userId) {
         return lectureService.getRegisteredLectures(userId);
     }
 }

--- a/src/main/java/com/hhplus/clean/architecture/application/LectureFacade.java
+++ b/src/main/java/com/hhplus/clean/architecture/application/LectureFacade.java
@@ -1,9 +1,12 @@
 package com.hhplus.clean.architecture.application;
 
+import com.hhplus.clean.architecture.domain.lecture.Lecture;
 import com.hhplus.clean.architecture.domain.lecture.LectureRegistration;
 import com.hhplus.clean.architecture.domain.lecture.LectureService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -13,6 +16,10 @@ public class LectureFacade {
 
     public LectureRegistration registerLecture(Long userId, Long lectureScheduleId) {
         return lectureService.registerLecture(userId, lectureScheduleId);
+    }
+
+    public List<Lecture> getLectures(){
+        return lectureService.getLectureList();
     }
 
 }

--- a/src/main/java/com/hhplus/clean/architecture/application/LectureFacade.java
+++ b/src/main/java/com/hhplus/clean/architecture/application/LectureFacade.java
@@ -1,0 +1,7 @@
+package com.hhplus.clean.architecture.application;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class LectureFacade {
+}

--- a/src/main/java/com/hhplus/clean/architecture/application/LectureFacade.java
+++ b/src/main/java/com/hhplus/clean/architecture/application/LectureFacade.java
@@ -1,9 +1,9 @@
 package com.hhplus.clean.architecture.application;
 
-import com.hhplus.clean.architecture.domain.lecture.Lecture;
-import com.hhplus.clean.architecture.domain.lecture.LectureRegistration;
 import com.hhplus.clean.architecture.domain.lecture.LectureService;
 import com.hhplus.clean.architecture.domain.lecture.model.LectureDetail;
+import com.hhplus.clean.architecture.domain.lecture.model.LectureInfo;
+import com.hhplus.clean.architecture.domain.lecture.model.RegistrationInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -15,11 +15,11 @@ public class LectureFacade {
 
     private final LectureService lectureService;
 
-    public LectureRegistration registerLecture(Long userId, Long lectureScheduleId) {
+    public RegistrationInfo registerLecture(Long userId, Long lectureScheduleId) {
         return lectureService.registerLecture(userId, lectureScheduleId);
     }
 
-    public List<Lecture> getLectures(){
+    public List<LectureInfo> getLectures(){
         return lectureService.getLectureList();
     }
 

--- a/src/main/java/com/hhplus/clean/architecture/application/LectureFacade.java
+++ b/src/main/java/com/hhplus/clean/architecture/application/LectureFacade.java
@@ -1,7 +1,18 @@
 package com.hhplus.clean.architecture.application;
 
+import com.hhplus.clean.architecture.domain.lecture.LectureRegistration;
+import com.hhplus.clean.architecture.domain.lecture.LectureService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class LectureFacade {
+
+    private final LectureService lectureService;
+
+    public LectureRegistration registerLecture(Long userId, Long lectureScheduleId) {
+        return lectureService.registerLecture(userId, lectureScheduleId);
+    }
+
 }

--- a/src/main/java/com/hhplus/clean/architecture/domain/error/BusinessException.java
+++ b/src/main/java/com/hhplus/clean/architecture/domain/error/BusinessException.java
@@ -1,0 +1,15 @@
+package com.hhplus.clean.architecture.domain.error;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+
+    }
+}

--- a/src/main/java/com/hhplus/clean/architecture/domain/error/BusinessExceptionCode.java
+++ b/src/main/java/com/hhplus/clean/architecture/domain/error/BusinessExceptionCode.java
@@ -1,7 +1,41 @@
 package com.hhplus.clean.architecture.domain.error;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @Getter
-public enum BusinessExceptionCode {
+@RequiredArgsConstructor
+public enum BusinessExceptionCode implements ErrorCode{
+
+    // NOT_FOUND
+    LECTURE_NOT_FOUND(HttpStatus.NOT_FOUND, "강의를 찾을 수 없습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+
+    //수강 신청 관련 예외
+    DUPLICATE_ENROLLMENT(HttpStatus.BAD_REQUEST, "이미 수강신청 완료하였습니다."),
+    LECTURE_FULL(HttpStatus.BAD_REQUEST, "수강인원이 가득 찼습니다."),
+
+
+    // 기타 에러
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다.");
+
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public String getCode() {
+        return name();
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
 }

--- a/src/main/java/com/hhplus/clean/architecture/domain/error/BusinessExceptionCode.java
+++ b/src/main/java/com/hhplus/clean/architecture/domain/error/BusinessExceptionCode.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum BusinessExceptionCode implements ErrorCode{
 
     // NOT_FOUND
-    LECTURE_NOT_FOUND(HttpStatus.NOT_FOUND, "강의를 찾을 수 없습니다."),
+    LECTURE_NOT_FOUND(HttpStatus.NOT_FOUND, "신청 가능한 강의가 없습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
 
     //수강 신청 관련 예외

--- a/src/main/java/com/hhplus/clean/architecture/domain/error/BusinessExceptionCode.java
+++ b/src/main/java/com/hhplus/clean/architecture/domain/error/BusinessExceptionCode.java
@@ -1,0 +1,7 @@
+package com.hhplus.clean.architecture.domain.error;
+
+import lombok.Getter;
+
+@Getter
+public enum BusinessExceptionCode {
+}

--- a/src/main/java/com/hhplus/clean/architecture/domain/error/BusinessExceptionCode.java
+++ b/src/main/java/com/hhplus/clean/architecture/domain/error/BusinessExceptionCode.java
@@ -15,6 +15,7 @@ public enum BusinessExceptionCode implements ErrorCode{
     //수강 신청 관련 예외
     DUPLICATE_ENROLLMENT(HttpStatus.BAD_REQUEST, "이미 수강신청 완료하였습니다."),
     LECTURE_FULL(HttpStatus.BAD_REQUEST, "수강인원이 가득 찼습니다."),
+    REGISTRATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "수강신청 완료된 강의가 없습니다."),
 
 
     // 기타 에러

--- a/src/main/java/com/hhplus/clean/architecture/domain/error/ErrorCode.java
+++ b/src/main/java/com/hhplus/clean/architecture/domain/error/ErrorCode.java
@@ -1,0 +1,9 @@
+package com.hhplus.clean.architecture.domain.error;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    String getCode();
+    HttpStatus getStatus();
+    String getMessage();
+}

--- a/src/main/java/com/hhplus/clean/architecture/domain/lecture/Lecture.java
+++ b/src/main/java/com/hhplus/clean/architecture/domain/lecture/Lecture.java
@@ -1,0 +1,14 @@
+package com.hhplus.clean.architecture.domain.lecture;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+@Entity
+public class Lecture {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+}

--- a/src/main/java/com/hhplus/clean/architecture/domain/lecture/Lecture.java
+++ b/src/main/java/com/hhplus/clean/architecture/domain/lecture/Lecture.java
@@ -1,14 +1,24 @@
 package com.hhplus.clean.architecture.domain.lecture;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class Lecture {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String instructor;
 
 }

--- a/src/main/java/com/hhplus/clean/architecture/domain/lecture/LectureRegistration.java
+++ b/src/main/java/com/hhplus/clean/architecture/domain/lecture/LectureRegistration.java
@@ -1,0 +1,14 @@
+package com.hhplus.clean.architecture.domain.lecture;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+@Entity
+public class LectureRegistration {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+}

--- a/src/main/java/com/hhplus/clean/architecture/domain/lecture/LectureRegistration.java
+++ b/src/main/java/com/hhplus/clean/architecture/domain/lecture/LectureRegistration.java
@@ -1,14 +1,39 @@
 package com.hhplus.clean.architecture.domain.lecture;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import com.hhplus.clean.architecture.domain.user.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 @Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "lecture_registration", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "lecture_schedule_id"})
+})
 public class LectureRegistration {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lecture_schedule_id", nullable = false)
+    private LectureSchedule lectureSchedule;
+
+    @Column(nullable = false)
+    private LocalDateTime registerDateTime;
+
+    public static LectureRegistration create(User user, LectureSchedule lectureSchedule) {
+        return new LectureRegistration(null,user, lectureSchedule, LocalDateTime.now());
+    }
 
 }

--- a/src/main/java/com/hhplus/clean/architecture/domain/lecture/LectureRepository.java
+++ b/src/main/java/com/hhplus/clean/architecture/domain/lecture/LectureRepository.java
@@ -1,0 +1,4 @@
+package com.hhplus.clean.architecture.domain.lecture;
+
+public interface LectureRepository {
+}

--- a/src/main/java/com/hhplus/clean/architecture/domain/lecture/LectureRepository.java
+++ b/src/main/java/com/hhplus/clean/architecture/domain/lecture/LectureRepository.java
@@ -2,6 +2,8 @@ package com.hhplus.clean.architecture.domain.lecture;
 
 import com.hhplus.clean.architecture.domain.user.User;
 
+import java.util.List;
+
 public interface LectureRepository {
 
     LectureSchedule getLectureSchedule(Long lectureScheduleId);
@@ -9,4 +11,7 @@ public interface LectureRepository {
     LectureRegistration completeLectureRegistration(LectureRegistration registration);
 
     boolean isUserAlreadyRegistered(User user, LectureSchedule schedule);
+
+    List<Lecture> getLectureList();
+
 }

--- a/src/main/java/com/hhplus/clean/architecture/domain/lecture/LectureRepository.java
+++ b/src/main/java/com/hhplus/clean/architecture/domain/lecture/LectureRepository.java
@@ -14,4 +14,7 @@ public interface LectureRepository {
 
     List<Lecture> getLectureList();
 
+    Lecture getLecture(Long lectureId);
+
+    List<LectureSchedule> getLectureScheduleList(Long lectureId);
 }

--- a/src/main/java/com/hhplus/clean/architecture/domain/lecture/LectureRepository.java
+++ b/src/main/java/com/hhplus/clean/architecture/domain/lecture/LectureRepository.java
@@ -1,4 +1,12 @@
 package com.hhplus.clean.architecture.domain.lecture;
 
+import com.hhplus.clean.architecture.domain.user.User;
+
 public interface LectureRepository {
+
+    LectureSchedule getLectureSchedule(Long lectureScheduleId);
+
+    LectureRegistration completeLectureRegistration(LectureRegistration registration);
+
+    boolean isUserAlreadyRegistered(User user, LectureSchedule schedule);
 }

--- a/src/main/java/com/hhplus/clean/architecture/domain/lecture/LectureRepository.java
+++ b/src/main/java/com/hhplus/clean/architecture/domain/lecture/LectureRepository.java
@@ -17,4 +17,6 @@ public interface LectureRepository {
     Lecture getLecture(Long lectureId);
 
     List<LectureSchedule> getLectureScheduleList(Long lectureId);
+
+    List<LectureRegistration> getRegistrationList(Long userId);
 }

--- a/src/main/java/com/hhplus/clean/architecture/domain/lecture/LectureSchedule.java
+++ b/src/main/java/com/hhplus/clean/architecture/domain/lecture/LectureSchedule.java
@@ -1,0 +1,14 @@
+package com.hhplus.clean.architecture.domain.lecture;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+@Entity
+public class LectureSchedule {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+}

--- a/src/main/java/com/hhplus/clean/architecture/domain/lecture/LectureSchedule.java
+++ b/src/main/java/com/hhplus/clean/architecture/domain/lecture/LectureSchedule.java
@@ -1,14 +1,45 @@
 package com.hhplus.clean.architecture.domain.lecture;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import com.hhplus.clean.architecture.domain.error.BusinessException;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+import static com.hhplus.clean.architecture.domain.error.BusinessExceptionCode.LECTURE_FULL;
+
 
 @Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class LectureSchedule {
 
+    private static final int MAX_CAPACITY = 30;
+
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lecture_id", nullable = false)
+    private Lecture lecture;
+
+
+    @Column(nullable = false)
+    private int capacity = MAX_CAPACITY;
+
+    @Column(nullable = false)
+    private LocalDate scheduleDate;
+
+    public void reduceCapacity() {
+        if (this.capacity <= 0) {
+            throw new BusinessException(LECTURE_FULL);
+        }
+        this.capacity -= 1;
+    }
+
 
 }

--- a/src/main/java/com/hhplus/clean/architecture/domain/lecture/LectureService.java
+++ b/src/main/java/com/hhplus/clean/architecture/domain/lecture/LectureService.java
@@ -2,6 +2,8 @@ package com.hhplus.clean.architecture.domain.lecture;
 
 import com.hhplus.clean.architecture.domain.error.BusinessException;
 import com.hhplus.clean.architecture.domain.lecture.model.LectureDetail;
+import com.hhplus.clean.architecture.domain.lecture.model.LectureInfo;
+import com.hhplus.clean.architecture.domain.lecture.model.RegistrationInfo;
 import com.hhplus.clean.architecture.domain.lecture.model.ScheduleInfo;
 import com.hhplus.clean.architecture.domain.user.User;
 import com.hhplus.clean.architecture.domain.user.UserRepository;
@@ -12,6 +14,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.hhplus.clean.architecture.domain.error.BusinessExceptionCode.DUPLICATE_ENROLLMENT;
 
@@ -22,7 +25,7 @@ public class LectureService {
     private final LectureRepository lectureRepository;
     private final UserRepository userRepository;
 
-    public LectureRegistration registerLecture(Long userId, Long lectureScheduleId) {
+    public RegistrationInfo registerLecture(Long userId, Long lectureScheduleId) {
         User user = userRepository.getUser(userId);
         LectureSchedule schedule = lectureRepository.getLectureSchedule(lectureScheduleId);
 
@@ -33,13 +36,32 @@ public class LectureService {
 
         schedule.reduceCapacity();
         LectureRegistration registration = LectureRegistration.create(user, schedule);
-        LectureRegistration savedLecture = lectureRepository.completeLectureRegistration(registration);
+        RegistrationInfo registrationInfo = new RegistrationInfo(
+                registration.getId(),user.getId(),
+                user.getName(),
+                schedule.getId(),
+                schedule.getLecture().getId(),
+                schedule.getLecture().getTitle(),
+                schedule.getScheduleDate()
+                );
 
-        return savedLecture;
+        lectureRepository.completeLectureRegistration(registration);
+
+        return registrationInfo;
     }
 
-    public List<Lecture> getLectureList() {
-        return lectureRepository.getLectureList();
+    public List<LectureInfo> getLectureList() {
+        List<Lecture> lectures = lectureRepository.getLectureList();
+
+        List<LectureInfo> lectureInfos = lectures.stream()
+                .map(lecture -> new LectureInfo(
+                        lecture.getId(),
+                        lecture.getTitle(),
+                        lecture.getInstructor()
+                ))
+                .collect(Collectors.toList());
+
+        return lectureInfos;
     }
 
     public LectureDetail getLectureWithSchedule(Long lectureId){

--- a/src/main/java/com/hhplus/clean/architecture/domain/lecture/LectureService.java
+++ b/src/main/java/com/hhplus/clean/architecture/domain/lecture/LectureService.java
@@ -6,6 +6,8 @@ import com.hhplus.clean.architecture.domain.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 import static com.hhplus.clean.architecture.domain.error.BusinessExceptionCode.DUPLICATE_ENROLLMENT;
 
 @Service
@@ -26,9 +28,13 @@ public class LectureService {
 
         schedule.reduceCapacity();
         LectureRegistration registration = LectureRegistration.create(user, schedule);
-        LectureRegistration savedLecture =  lectureRepository.completeLectureRegistration(registration);
+        LectureRegistration savedLecture = lectureRepository.completeLectureRegistration(registration);
 
         return savedLecture;
+    }
+
+    public List<Lecture> getLectureList() {
+        return lectureRepository.getLectureList();
     }
 
 

--- a/src/main/java/com/hhplus/clean/architecture/domain/lecture/LectureService.java
+++ b/src/main/java/com/hhplus/clean/architecture/domain/lecture/LectureService.java
@@ -1,7 +1,7 @@
 package com.hhplus.clean.architecture.domain.lecture;
 
 import com.hhplus.clean.architecture.domain.error.BusinessException;
-import com.hhplus.clean.architecture.domain.lecture.model.LectureInfo;
+import com.hhplus.clean.architecture.domain.lecture.model.LectureDetail;
 import com.hhplus.clean.architecture.domain.lecture.model.ScheduleInfo;
 import com.hhplus.clean.architecture.domain.user.User;
 import com.hhplus.clean.architecture.domain.user.UserRepository;
@@ -42,7 +42,7 @@ public class LectureService {
         return lectureRepository.getLectureList();
     }
 
-    public LectureInfo getLectureWithSchedule(Long lectureId){
+    public LectureDetail getLectureWithSchedule(Long lectureId){
         Lecture lecture = lectureRepository.getLecture(lectureId);
         List<LectureSchedule> schedules = lectureRepository.getLectureScheduleList(lectureId)
                 .stream()
@@ -53,12 +53,12 @@ public class LectureService {
                 .map(schedule -> new ScheduleInfo(schedule.getId(), schedule.getCapacity(), schedule.getScheduleDate()))
                 .toList();
 
-        LectureInfo lectureInfo = new LectureInfo(lectureId, lecture.getTitle(), lecture.getInstructor(), scheduleInfos);
+        LectureDetail lectureDetail = new LectureDetail(lectureId, lecture.getTitle(), lecture.getInstructor(), scheduleInfos);
 
-        return lectureInfo;
+        return lectureDetail;
     }
 
-    public List<LectureInfo> getRegisteredLectures(Long userId) {
+    public List<LectureDetail> getRegisteredLectures(Long userId) {
         userRepository.getUser(userId);
 
         List<LectureRegistration> registrations = lectureRepository.getRegistrationList(userId);
@@ -78,12 +78,12 @@ public class LectureService {
                     .add(scheduleInfo);
         }
 
-        List<LectureInfo> registeredLectures = new ArrayList<>();
+        List<LectureDetail> registeredLectures = new ArrayList<>();
         for (Map.Entry<Lecture, List<ScheduleInfo>> entry : lectureScheduleMap.entrySet()) {
             Lecture lecture = entry.getKey();
             List<ScheduleInfo> scheduleInfos = entry.getValue();
 
-            registeredLectures.add(new LectureInfo(
+            registeredLectures.add(new LectureDetail(
                     lecture.getId(),
                     lecture.getTitle(),
                     lecture.getInstructor(),

--- a/src/main/java/com/hhplus/clean/architecture/domain/lecture/LectureService.java
+++ b/src/main/java/com/hhplus/clean/architecture/domain/lecture/LectureService.java
@@ -1,7 +1,35 @@
 package com.hhplus.clean.architecture.domain.lecture;
 
+import com.hhplus.clean.architecture.domain.error.BusinessException;
+import com.hhplus.clean.architecture.domain.user.User;
+import com.hhplus.clean.architecture.domain.user.UserRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import static com.hhplus.clean.architecture.domain.error.BusinessExceptionCode.DUPLICATE_ENROLLMENT;
+
 @Service
+@RequiredArgsConstructor
 public class LectureService {
+
+    private final LectureRepository lectureRepository;
+    private final UserRepository userRepository;
+
+    public LectureRegistration registerLecture(Long userId, Long lectureScheduleId) {
+        User user = userRepository.getUser(userId);
+        LectureSchedule schedule = lectureRepository.getLectureSchedule(lectureScheduleId);
+
+        boolean isAlreadyRegisteredForLecture = lectureRepository.isUserAlreadyRegistered(user, schedule);
+        if (isAlreadyRegisteredForLecture) {
+            throw new BusinessException(DUPLICATE_ENROLLMENT);
+        }
+
+        schedule.reduceCapacity();
+        LectureRegistration registration = LectureRegistration.create(user, schedule);
+        LectureRegistration savedLecture =  lectureRepository.completeLectureRegistration(registration);
+
+        return savedLecture;
+    }
+
+
 }

--- a/src/main/java/com/hhplus/clean/architecture/domain/lecture/LectureService.java
+++ b/src/main/java/com/hhplus/clean/architecture/domain/lecture/LectureService.java
@@ -1,0 +1,7 @@
+package com.hhplus.clean.architecture.domain.lecture;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class LectureService {
+}

--- a/src/main/java/com/hhplus/clean/architecture/domain/lecture/LectureService.java
+++ b/src/main/java/com/hhplus/clean/architecture/domain/lecture/LectureService.java
@@ -1,6 +1,8 @@
 package com.hhplus.clean.architecture.domain.lecture;
 
 import com.hhplus.clean.architecture.domain.error.BusinessException;
+import com.hhplus.clean.architecture.domain.lecture.model.LectureInfo;
+import com.hhplus.clean.architecture.domain.lecture.model.ScheduleInfo;
 import com.hhplus.clean.architecture.domain.user.User;
 import com.hhplus.clean.architecture.domain.user.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -37,5 +39,20 @@ public class LectureService {
         return lectureRepository.getLectureList();
     }
 
+    public LectureInfo getLectureWithSchedule(Long lectureId){
+        Lecture lecture = lectureRepository.getLecture(lectureId);
+        List<LectureSchedule> schedules = lectureRepository.getLectureScheduleList(lectureId)
+                .stream()
+                .filter(schedule -> schedule.getCapacity() > 0)
+                .toList();
+
+        List<ScheduleInfo> scheduleInfos = schedules.stream()
+                .map(schedule -> new ScheduleInfo(schedule.getId(), schedule.getCapacity(), schedule.getScheduleDate()))
+                .toList();
+
+        LectureInfo lectureInfo = new LectureInfo(lectureId, lecture.getTitle(), lecture.getInstructor(), scheduleInfos);
+
+        return lectureInfo;
+    }
 
 }

--- a/src/main/java/com/hhplus/clean/architecture/domain/lecture/LectureService.java
+++ b/src/main/java/com/hhplus/clean/architecture/domain/lecture/LectureService.java
@@ -9,6 +9,7 @@ import com.hhplus.clean.architecture.domain.user.User;
 import com.hhplus.clean.architecture.domain.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -25,6 +26,7 @@ public class LectureService {
     private final LectureRepository lectureRepository;
     private final UserRepository userRepository;
 
+    @Transactional
     public RegistrationInfo registerLecture(Long userId, Long lectureScheduleId) {
         User user = userRepository.getUser(userId);
         LectureSchedule schedule = lectureRepository.getLectureSchedule(lectureScheduleId);
@@ -50,6 +52,7 @@ public class LectureService {
         return registrationInfo;
     }
 
+    @Transactional(readOnly = true)
     public List<LectureInfo> getLectureList() {
         List<Lecture> lectures = lectureRepository.getLectureList();
 
@@ -64,6 +67,7 @@ public class LectureService {
         return lectureInfos;
     }
 
+    @Transactional(readOnly = true)
     public LectureDetail getLectureWithSchedule(Long lectureId){
         Lecture lecture = lectureRepository.getLecture(lectureId);
         List<LectureSchedule> schedules = lectureRepository.getLectureScheduleList(lectureId)
@@ -80,6 +84,7 @@ public class LectureService {
         return lectureDetail;
     }
 
+    @Transactional(readOnly = true)
     public List<LectureDetail> getRegisteredLectures(Long userId) {
         userRepository.getUser(userId);
 

--- a/src/main/java/com/hhplus/clean/architecture/domain/lecture/model/LectureDetail.java
+++ b/src/main/java/com/hhplus/clean/architecture/domain/lecture/model/LectureDetail.java
@@ -2,7 +2,7 @@ package com.hhplus.clean.architecture.domain.lecture.model;
 
 import java.util.List;
 
-public record LectureInfo(
+public record LectureDetail(
         Long lectureId,
         String title,
         String instructor,

--- a/src/main/java/com/hhplus/clean/architecture/domain/lecture/model/LectureInfo.java
+++ b/src/main/java/com/hhplus/clean/architecture/domain/lecture/model/LectureInfo.java
@@ -1,0 +1,7 @@
+package com.hhplus.clean.architecture.domain.lecture.model;
+
+public record LectureInfo(
+        Long lectureId,
+        String title,
+        String instructor
+) { }

--- a/src/main/java/com/hhplus/clean/architecture/domain/lecture/model/LectureInfo.java
+++ b/src/main/java/com/hhplus/clean/architecture/domain/lecture/model/LectureInfo.java
@@ -1,0 +1,10 @@
+package com.hhplus.clean.architecture.domain.lecture.model;
+
+import java.util.List;
+
+public record LectureInfo(
+        Long lectureId,
+        String title,
+        String instructor,
+        List<ScheduleInfo> scheduleInfos
+) { }

--- a/src/main/java/com/hhplus/clean/architecture/domain/lecture/model/RegistrationInfo.java
+++ b/src/main/java/com/hhplus/clean/architecture/domain/lecture/model/RegistrationInfo.java
@@ -1,0 +1,13 @@
+package com.hhplus.clean.architecture.domain.lecture.model;
+
+import java.time.LocalDate;
+
+public record RegistrationInfo(
+        Long registerId,
+        Long userId,
+        String userName,
+        Long scheduleId,
+        Long lectureId,
+        String title,
+        LocalDate scheduleDate
+) { }

--- a/src/main/java/com/hhplus/clean/architecture/domain/lecture/model/ScheduleInfo.java
+++ b/src/main/java/com/hhplus/clean/architecture/domain/lecture/model/ScheduleInfo.java
@@ -1,0 +1,9 @@
+package com.hhplus.clean.architecture.domain.lecture.model;
+
+import java.time.LocalDate;
+
+public record ScheduleInfo(
+        Long scheduleId,
+        int capacity,
+        LocalDate scheduleDate
+) { }

--- a/src/main/java/com/hhplus/clean/architecture/domain/user/User.java
+++ b/src/main/java/com/hhplus/clean/architecture/domain/user/User.java
@@ -1,0 +1,16 @@
+package com.hhplus.clean.architecture.domain.user;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name="users")
+public class User {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+}

--- a/src/main/java/com/hhplus/clean/architecture/domain/user/User.java
+++ b/src/main/java/com/hhplus/clean/architecture/domain/user/User.java
@@ -1,16 +1,23 @@
 package com.hhplus.clean.architecture.domain.user;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
-@Table(name="users")
+@Getter@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "users")
 public class User {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false)
+    private String name;
 
 }

--- a/src/main/java/com/hhplus/clean/architecture/domain/user/UserRepository.java
+++ b/src/main/java/com/hhplus/clean/architecture/domain/user/UserRepository.java
@@ -1,4 +1,5 @@
 package com.hhplus.clean.architecture.domain.user;
 
 public interface UserRepository {
+    User getUser(Long userId);
 }

--- a/src/main/java/com/hhplus/clean/architecture/domain/user/UserRepository.java
+++ b/src/main/java/com/hhplus/clean/architecture/domain/user/UserRepository.java
@@ -1,0 +1,4 @@
+package com.hhplus.clean.architecture.domain.user;
+
+public interface UserRepository {
+}

--- a/src/main/java/com/hhplus/clean/architecture/infrastructure/lecture/LectureJpaRepository.java
+++ b/src/main/java/com/hhplus/clean/architecture/infrastructure/lecture/LectureJpaRepository.java
@@ -1,0 +1,9 @@
+package com.hhplus.clean.architecture.infrastructure.lecture;
+
+import com.hhplus.clean.architecture.domain.lecture.Lecture;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LectureJpaRepository extends JpaRepository<Lecture,Long> {
+}

--- a/src/main/java/com/hhplus/clean/architecture/infrastructure/lecture/LectureRegistrationJpaRepository.java
+++ b/src/main/java/com/hhplus/clean/architecture/infrastructure/lecture/LectureRegistrationJpaRepository.java
@@ -1,0 +1,9 @@
+package com.hhplus.clean.architecture.infrastructure.lecture;
+
+import com.hhplus.clean.architecture.domain.lecture.LectureRegistration;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LectureRegistrationJpaRepository extends JpaRepository<LectureRegistration,Long> {
+}

--- a/src/main/java/com/hhplus/clean/architecture/infrastructure/lecture/LectureRegistrationJpaRepository.java
+++ b/src/main/java/com/hhplus/clean/architecture/infrastructure/lecture/LectureRegistrationJpaRepository.java
@@ -1,9 +1,12 @@
 package com.hhplus.clean.architecture.infrastructure.lecture;
 
 import com.hhplus.clean.architecture.domain.lecture.LectureRegistration;
+import com.hhplus.clean.architecture.domain.lecture.LectureSchedule;
+import com.hhplus.clean.architecture.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LectureRegistrationJpaRepository extends JpaRepository<LectureRegistration,Long> {
+    boolean existsByUserAndLectureSchedule(User user, LectureSchedule lectureSchedule);
 }

--- a/src/main/java/com/hhplus/clean/architecture/infrastructure/lecture/LectureRegistrationJpaRepository.java
+++ b/src/main/java/com/hhplus/clean/architecture/infrastructure/lecture/LectureRegistrationJpaRepository.java
@@ -6,7 +6,10 @@ import com.hhplus.clean.architecture.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface LectureRegistrationJpaRepository extends JpaRepository<LectureRegistration,Long> {
     boolean existsByUserAndLectureSchedule(User user, LectureSchedule lectureSchedule);
+    List<LectureRegistration> findByUserId(Long userId);
 }

--- a/src/main/java/com/hhplus/clean/architecture/infrastructure/lecture/LectureRepositoryImpl.java
+++ b/src/main/java/com/hhplus/clean/architecture/infrastructure/lecture/LectureRepositoryImpl.java
@@ -1,0 +1,13 @@
+package com.hhplus.clean.architecture.infrastructure.lecture;
+
+import com.hhplus.clean.architecture.domain.lecture.LectureRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class LectureRepositoryImpl implements LectureRepository {
+    private final LectureJpaRepository lectureJpaRepository;
+    private final LectureScheduleJpaRepository scheduleJpaRepository;
+    private final LectureRegistrationJpaRepository registrationJpaRepository;
+}

--- a/src/main/java/com/hhplus/clean/architecture/infrastructure/lecture/LectureRepositoryImpl.java
+++ b/src/main/java/com/hhplus/clean/architecture/infrastructure/lecture/LectureRepositoryImpl.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 import static com.hhplus.clean.architecture.domain.error.BusinessExceptionCode.LECTURE_NOT_FOUND;
+import static com.hhplus.clean.architecture.domain.error.BusinessExceptionCode.REGISTRATION_NOT_FOUND;
 
 @Repository
 @RequiredArgsConstructor
@@ -58,6 +59,15 @@ public class LectureRepositoryImpl implements LectureRepository {
             throw new BusinessException(LECTURE_NOT_FOUND);
         }
         return schedules;
+    }
+
+    @Override
+    public List<LectureRegistration> getRegistrationList(Long userId) {
+        List<LectureRegistration> registrations = registrationJpaRepository.findByUserId(userId);
+        if (registrations.isEmpty()) {
+            throw new BusinessException(REGISTRATION_NOT_FOUND);
+        }
+        return registrationJpaRepository.findByUserId(userId);
     }
 
 }

--- a/src/main/java/com/hhplus/clean/architecture/infrastructure/lecture/LectureRepositoryImpl.java
+++ b/src/main/java/com/hhplus/clean/architecture/infrastructure/lecture/LectureRepositoryImpl.java
@@ -45,4 +45,19 @@ public class LectureRepositoryImpl implements LectureRepository {
         return lectures;
     }
 
+    @Override
+    public Lecture getLecture(Long lectureId) {
+        return lectureJpaRepository.findById(lectureId)
+                .orElseThrow(() -> new BusinessException(LECTURE_NOT_FOUND));
+    }
+
+    @Override
+    public List<LectureSchedule> getLectureScheduleList(Long lectureId) {
+        List<LectureSchedule> schedules = scheduleJpaRepository.findByLectureIdOrderByScheduleDateAsc(lectureId);
+        if(schedules.isEmpty()){
+            throw new BusinessException(LECTURE_NOT_FOUND);
+        }
+        return schedules;
+    }
+
 }

--- a/src/main/java/com/hhplus/clean/architecture/infrastructure/lecture/LectureRepositoryImpl.java
+++ b/src/main/java/com/hhplus/clean/architecture/infrastructure/lecture/LectureRepositoryImpl.java
@@ -1,12 +1,15 @@
 package com.hhplus.clean.architecture.infrastructure.lecture;
 
 import com.hhplus.clean.architecture.domain.error.BusinessException;
+import com.hhplus.clean.architecture.domain.lecture.Lecture;
 import com.hhplus.clean.architecture.domain.lecture.LectureRegistration;
 import com.hhplus.clean.architecture.domain.lecture.LectureRepository;
 import com.hhplus.clean.architecture.domain.lecture.LectureSchedule;
 import com.hhplus.clean.architecture.domain.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 import static com.hhplus.clean.architecture.domain.error.BusinessExceptionCode.LECTURE_NOT_FOUND;
 
@@ -31,6 +34,15 @@ public class LectureRepositoryImpl implements LectureRepository {
     @Override
     public boolean isUserAlreadyRegistered(User user, LectureSchedule schedule) {
         return registrationJpaRepository.existsByUserAndLectureSchedule(user,schedule);
+    }
+
+    @Override
+    public List<Lecture> getLectureList() {
+        List<Lecture> lectures = lectureJpaRepository.findAll();
+        if(lectures.isEmpty()) {
+            throw new BusinessException(LECTURE_NOT_FOUND);
+        }
+        return lectures;
     }
 
 }

--- a/src/main/java/com/hhplus/clean/architecture/infrastructure/lecture/LectureRepositoryImpl.java
+++ b/src/main/java/com/hhplus/clean/architecture/infrastructure/lecture/LectureRepositoryImpl.java
@@ -1,8 +1,14 @@
 package com.hhplus.clean.architecture.infrastructure.lecture;
 
+import com.hhplus.clean.architecture.domain.error.BusinessException;
+import com.hhplus.clean.architecture.domain.lecture.LectureRegistration;
 import com.hhplus.clean.architecture.domain.lecture.LectureRepository;
+import com.hhplus.clean.architecture.domain.lecture.LectureSchedule;
+import com.hhplus.clean.architecture.domain.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import static com.hhplus.clean.architecture.domain.error.BusinessExceptionCode.LECTURE_NOT_FOUND;
 
 @Repository
 @RequiredArgsConstructor
@@ -10,4 +16,21 @@ public class LectureRepositoryImpl implements LectureRepository {
     private final LectureJpaRepository lectureJpaRepository;
     private final LectureScheduleJpaRepository scheduleJpaRepository;
     private final LectureRegistrationJpaRepository registrationJpaRepository;
+
+    @Override
+    public LectureSchedule getLectureSchedule(Long lectureScheduleId) {
+            return scheduleJpaRepository.findById(lectureScheduleId)
+                    .orElseThrow(() -> new BusinessException(LECTURE_NOT_FOUND));
+    }
+
+    @Override
+    public LectureRegistration completeLectureRegistration(LectureRegistration registration) {
+        return registrationJpaRepository.save(registration);
+    }
+
+    @Override
+    public boolean isUserAlreadyRegistered(User user, LectureSchedule schedule) {
+        return registrationJpaRepository.existsByUserAndLectureSchedule(user,schedule);
+    }
+
 }

--- a/src/main/java/com/hhplus/clean/architecture/infrastructure/lecture/LectureScheduleJpaRepository.java
+++ b/src/main/java/com/hhplus/clean/architecture/infrastructure/lecture/LectureScheduleJpaRepository.java
@@ -1,0 +1,9 @@
+package com.hhplus.clean.architecture.infrastructure.lecture;
+
+import com.hhplus.clean.architecture.domain.lecture.LectureSchedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LectureScheduleJpaRepository extends JpaRepository<LectureSchedule,Long> {
+}

--- a/src/main/java/com/hhplus/clean/architecture/infrastructure/lecture/LectureScheduleJpaRepository.java
+++ b/src/main/java/com/hhplus/clean/architecture/infrastructure/lecture/LectureScheduleJpaRepository.java
@@ -4,6 +4,9 @@ import com.hhplus.clean.architecture.domain.lecture.LectureSchedule;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface LectureScheduleJpaRepository extends JpaRepository<LectureSchedule,Long> {
+    List<LectureSchedule> findByLectureIdOrderByScheduleDateAsc(Long lectureId);
 }

--- a/src/main/java/com/hhplus/clean/architecture/infrastructure/user/UserJpaRepository.java
+++ b/src/main/java/com/hhplus/clean/architecture/infrastructure/user/UserJpaRepository.java
@@ -1,0 +1,9 @@
+package com.hhplus.clean.architecture.infrastructure.user;
+
+import com.hhplus.clean.architecture.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserJpaRepository extends JpaRepository<User,Long> {
+}

--- a/src/main/java/com/hhplus/clean/architecture/infrastructure/user/UserRepositoryImpl.java
+++ b/src/main/java/com/hhplus/clean/architecture/infrastructure/user/UserRepositoryImpl.java
@@ -1,0 +1,11 @@
+package com.hhplus.clean.architecture.infrastructure.user;
+
+import com.hhplus.clean.architecture.domain.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepository {
+    private final UserJpaRepository userJpaRepository;
+}

--- a/src/main/java/com/hhplus/clean/architecture/infrastructure/user/UserRepositoryImpl.java
+++ b/src/main/java/com/hhplus/clean/architecture/infrastructure/user/UserRepositoryImpl.java
@@ -1,11 +1,21 @@
 package com.hhplus.clean.architecture.infrastructure.user;
 
+import com.hhplus.clean.architecture.domain.error.BusinessException;
+import com.hhplus.clean.architecture.domain.user.User;
 import com.hhplus.clean.architecture.domain.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import static com.hhplus.clean.architecture.domain.error.BusinessExceptionCode.USER_NOT_FOUND;
 
 @Repository
 @RequiredArgsConstructor
 public class UserRepositoryImpl implements UserRepository {
     private final UserJpaRepository userJpaRepository;
+
+    @Override
+    public User getUser(Long userId) {
+        return userJpaRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/hhplus/clean/architecture/interfaces/ApiControllerAdvice.java
+++ b/src/main/java/com/hhplus/clean/architecture/interfaces/ApiControllerAdvice.java
@@ -1,0 +1,21 @@
+package com.hhplus.clean.architecture.interfaces;
+
+import com.hhplus.clean.architecture.domain.error.BusinessException;
+import com.hhplus.clean.architecture.domain.error.ErrorCode;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ApiControllerAdvice {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException ex) {
+        ErrorCode errorCode = ex.getErrorCode();
+        ErrorResponse errorResponse = new ErrorResponse(errorCode.getCode(), errorCode.getMessage(),errorCode.getStatus());
+        return new ResponseEntity<>(errorResponse, errorCode.getStatus());
+    }
+
+    public record ErrorResponse(String code, String message, HttpStatus status) {}
+}

--- a/src/main/java/com/hhplus/clean/architecture/interfaces/LectureController.java
+++ b/src/main/java/com/hhplus/clean/architecture/interfaces/LectureController.java
@@ -1,9 +1,9 @@
 package com.hhplus.clean.architecture.interfaces;
 
 import com.hhplus.clean.architecture.application.LectureFacade;
-import com.hhplus.clean.architecture.domain.lecture.Lecture;
-import com.hhplus.clean.architecture.domain.lecture.LectureRegistration;
 import com.hhplus.clean.architecture.domain.lecture.model.LectureDetail;
+import com.hhplus.clean.architecture.domain.lecture.model.LectureInfo;
+import com.hhplus.clean.architecture.domain.lecture.model.RegistrationInfo;
 import com.hhplus.clean.architecture.interfaces.dto.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,18 +20,15 @@ public class LectureController {
     private final LectureMapper lectureMapper;
 
     @PostMapping("register/{lectureScheduleId}")
-    public ResponseEntity<RegisterLectureRes> registerLecture(
-            @PathVariable Long lectureScheduleId, @RequestBody RegisterLectureReq userRequest) {
-
-        LectureRegistration registration = lectureFacade.registerLecture(userRequest.id(), lectureScheduleId);
+    public ResponseEntity<RegisterLectureRes> registerLecture(@PathVariable Long lectureScheduleId, @RequestBody RegisterLectureReq userRequest) {
+        RegistrationInfo registration = lectureFacade.registerLecture(userRequest.id(), lectureScheduleId);
         RegisterLectureRes response = lectureMapper.toRegisterLectureRes(registration);
-
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("lectures")
     public ResponseEntity<List<GetLecturesRes>> getLectures() {
-        List<Lecture> lectures = lectureFacade.getLectures();
+        List<LectureInfo> lectures = lectureFacade.getLectures();
         List<GetLecturesRes> response = lectureMapper.toGetLecturesRes(lectures);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/hhplus/clean/architecture/interfaces/LectureController.java
+++ b/src/main/java/com/hhplus/clean/architecture/interfaces/LectureController.java
@@ -1,12 +1,16 @@
 package com.hhplus.clean.architecture.interfaces;
 
 import com.hhplus.clean.architecture.application.LectureFacade;
+import com.hhplus.clean.architecture.domain.lecture.Lecture;
 import com.hhplus.clean.architecture.domain.lecture.LectureRegistration;
+import com.hhplus.clean.architecture.interfaces.dto.GetLecturesRes;
 import com.hhplus.clean.architecture.interfaces.dto.RegisterLectureReq;
 import com.hhplus.clean.architecture.interfaces.dto.RegisterLectureRes;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,5 +29,13 @@ public class LectureController {
 
         return ResponseEntity.ok(response);
     }
+
+    @GetMapping("/lectures")
+    public ResponseEntity<List<GetLecturesRes>> getLectures() {
+        List<Lecture> lectures = lectureFacade.getLectures();
+        List<GetLecturesRes> response = lectureMapper.toGetLecturesRes(lectures);
+        return ResponseEntity.ok(response);
+    }
+
 
 }

--- a/src/main/java/com/hhplus/clean/architecture/interfaces/LectureController.java
+++ b/src/main/java/com/hhplus/clean/architecture/interfaces/LectureController.java
@@ -1,7 +1,29 @@
 package com.hhplus.clean.architecture.interfaces;
 
-import org.springframework.web.bind.annotation.RestController;
+import com.hhplus.clean.architecture.application.LectureFacade;
+import com.hhplus.clean.architecture.domain.lecture.LectureRegistration;
+import com.hhplus.clean.architecture.interfaces.dto.RegisterLectureReq;
+import com.hhplus.clean.architecture.interfaces.dto.RegisterLectureRes;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/")
 public class LectureController {
+
+    private final LectureFacade lectureFacade;
+    private final LectureMapper lectureMapper;
+
+    @PostMapping("register/{lectureScheduleId}")
+    public ResponseEntity<RegisterLectureRes> registerLecture(
+            @PathVariable Long lectureScheduleId, @RequestBody RegisterLectureReq userRequest) {
+
+        LectureRegistration registration = lectureFacade.registerLecture(userRequest.id(), lectureScheduleId);
+        RegisterLectureRes response = lectureMapper.toRegisterLectureRes(registration);
+
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/java/com/hhplus/clean/architecture/interfaces/LectureController.java
+++ b/src/main/java/com/hhplus/clean/architecture/interfaces/LectureController.java
@@ -3,9 +3,11 @@ package com.hhplus.clean.architecture.interfaces;
 import com.hhplus.clean.architecture.application.LectureFacade;
 import com.hhplus.clean.architecture.domain.lecture.Lecture;
 import com.hhplus.clean.architecture.domain.lecture.LectureRegistration;
+import com.hhplus.clean.architecture.domain.lecture.model.LectureInfo;
 import com.hhplus.clean.architecture.interfaces.dto.GetLecturesRes;
 import com.hhplus.clean.architecture.interfaces.dto.RegisterLectureReq;
 import com.hhplus.clean.architecture.interfaces.dto.RegisterLectureRes;
+import com.hhplus.clean.architecture.interfaces.dto.GetLectureWithScheduleRes;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -30,12 +32,17 @@ public class LectureController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/lectures")
+    @GetMapping("lectures")
     public ResponseEntity<List<GetLecturesRes>> getLectures() {
         List<Lecture> lectures = lectureFacade.getLectures();
         List<GetLecturesRes> response = lectureMapper.toGetLecturesRes(lectures);
         return ResponseEntity.ok(response);
     }
 
-
+    @GetMapping("lectures/{lectureId}")
+    public ResponseEntity<GetLectureWithScheduleRes> getLectureWithSchedules(@PathVariable Long lectureId) {
+        LectureInfo lectureInfo = lectureFacade.getLectureWithSchedules(lectureId);
+        GetLectureWithScheduleRes response = lectureMapper.toGetLectureWithScheduleRes(lectureInfo);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/hhplus/clean/architecture/interfaces/LectureController.java
+++ b/src/main/java/com/hhplus/clean/architecture/interfaces/LectureController.java
@@ -4,10 +4,7 @@ import com.hhplus.clean.architecture.application.LectureFacade;
 import com.hhplus.clean.architecture.domain.lecture.Lecture;
 import com.hhplus.clean.architecture.domain.lecture.LectureRegistration;
 import com.hhplus.clean.architecture.domain.lecture.model.LectureInfo;
-import com.hhplus.clean.architecture.interfaces.dto.GetLecturesRes;
-import com.hhplus.clean.architecture.interfaces.dto.RegisterLectureReq;
-import com.hhplus.clean.architecture.interfaces.dto.RegisterLectureRes;
-import com.hhplus.clean.architecture.interfaces.dto.GetLectureWithScheduleRes;
+import com.hhplus.clean.architecture.interfaces.dto.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -45,4 +42,12 @@ public class LectureController {
         GetLectureWithScheduleRes response = lectureMapper.toGetLectureWithScheduleRes(lectureInfo);
         return ResponseEntity.ok(response);
     }
+
+    @GetMapping("/users/{userId}/lectures/registered")
+    public ResponseEntity<List<GetRegisteredLecturesRes>> getRegisteredLectures(@PathVariable Long userId){
+        List<LectureInfo> lectureInfos = lectureFacade.getRegisteredLectures(userId);
+        List<GetRegisteredLecturesRes> response = lectureMapper.toGetRegisteredLectureRes(lectureInfos);
+        return  ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/java/com/hhplus/clean/architecture/interfaces/LectureController.java
+++ b/src/main/java/com/hhplus/clean/architecture/interfaces/LectureController.java
@@ -1,0 +1,7 @@
+package com.hhplus.clean.architecture.interfaces;
+
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class LectureController {
+}

--- a/src/main/java/com/hhplus/clean/architecture/interfaces/LectureController.java
+++ b/src/main/java/com/hhplus/clean/architecture/interfaces/LectureController.java
@@ -3,7 +3,7 @@ package com.hhplus.clean.architecture.interfaces;
 import com.hhplus.clean.architecture.application.LectureFacade;
 import com.hhplus.clean.architecture.domain.lecture.Lecture;
 import com.hhplus.clean.architecture.domain.lecture.LectureRegistration;
-import com.hhplus.clean.architecture.domain.lecture.model.LectureInfo;
+import com.hhplus.clean.architecture.domain.lecture.model.LectureDetail;
 import com.hhplus.clean.architecture.interfaces.dto.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -38,15 +38,15 @@ public class LectureController {
 
     @GetMapping("lectures/{lectureId}")
     public ResponseEntity<GetLectureWithScheduleRes> getLectureWithSchedules(@PathVariable Long lectureId) {
-        LectureInfo lectureInfo = lectureFacade.getLectureWithSchedules(lectureId);
-        GetLectureWithScheduleRes response = lectureMapper.toGetLectureWithScheduleRes(lectureInfo);
+        LectureDetail lectureDetail = lectureFacade.getLectureWithSchedules(lectureId);
+        GetLectureWithScheduleRes response = lectureMapper.toGetLectureWithScheduleRes(lectureDetail);
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/users/{userId}/lectures/registered")
     public ResponseEntity<List<GetRegisteredLecturesRes>> getRegisteredLectures(@PathVariable Long userId){
-        List<LectureInfo> lectureInfos = lectureFacade.getRegisteredLectures(userId);
-        List<GetRegisteredLecturesRes> response = lectureMapper.toGetRegisteredLectureRes(lectureInfos);
+        List<LectureDetail> lectureDetails = lectureFacade.getRegisteredLectures(userId);
+        List<GetRegisteredLecturesRes> response = lectureMapper.toGetRegisteredLectureRes(lectureDetails);
         return  ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/hhplus/clean/architecture/interfaces/LectureMapper.java
+++ b/src/main/java/com/hhplus/clean/architecture/interfaces/LectureMapper.java
@@ -5,6 +5,7 @@ import com.hhplus.clean.architecture.domain.lecture.LectureRegistration;
 import com.hhplus.clean.architecture.domain.lecture.model.LectureInfo;
 import com.hhplus.clean.architecture.interfaces.dto.GetLectureWithScheduleRes;
 import com.hhplus.clean.architecture.interfaces.dto.GetLecturesRes;
+import com.hhplus.clean.architecture.interfaces.dto.GetRegisteredLecturesRes;
 import com.hhplus.clean.architecture.interfaces.dto.RegisterLectureRes;
 import org.springframework.stereotype.Component;
 
@@ -45,4 +46,14 @@ public class LectureMapper {
         );
     }
 
+    public List<GetRegisteredLecturesRes> toGetRegisteredLectureRes(List<LectureInfo> lectureInfos) {
+        return lectureInfos.stream()
+                .map(lectureInfo -> new GetRegisteredLecturesRes(
+                        lectureInfo.lectureId(),
+                        lectureInfo.title(),
+                        lectureInfo.instructor(),
+                        lectureInfo.scheduleInfos()
+                ))
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/hhplus/clean/architecture/interfaces/LectureMapper.java
+++ b/src/main/java/com/hhplus/clean/architecture/interfaces/LectureMapper.java
@@ -1,8 +1,13 @@
 package com.hhplus.clean.architecture.interfaces;
 
+import com.hhplus.clean.architecture.domain.lecture.Lecture;
 import com.hhplus.clean.architecture.domain.lecture.LectureRegistration;
+import com.hhplus.clean.architecture.interfaces.dto.GetLecturesRes;
 import com.hhplus.clean.architecture.interfaces.dto.RegisterLectureRes;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 public class LectureMapper {
@@ -17,6 +22,16 @@ public class LectureMapper {
                 registration.getLectureSchedule().getLecture().getTitle(),
                 registration.getLectureSchedule().getScheduleDate()
         );
+    }
+
+    public List<GetLecturesRes> toGetLecturesRes(List<Lecture> lectures) {
+        return lectures.stream()
+                .map(lecture -> new GetLecturesRes(
+                        lecture.getId(),
+                        lecture.getTitle(),
+                        lecture.getInstructor()
+                ))
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/com/hhplus/clean/architecture/interfaces/LectureMapper.java
+++ b/src/main/java/com/hhplus/clean/architecture/interfaces/LectureMapper.java
@@ -2,6 +2,8 @@ package com.hhplus.clean.architecture.interfaces;
 
 import com.hhplus.clean.architecture.domain.lecture.Lecture;
 import com.hhplus.clean.architecture.domain.lecture.LectureRegistration;
+import com.hhplus.clean.architecture.domain.lecture.model.LectureInfo;
+import com.hhplus.clean.architecture.interfaces.dto.GetLectureWithScheduleRes;
 import com.hhplus.clean.architecture.interfaces.dto.GetLecturesRes;
 import com.hhplus.clean.architecture.interfaces.dto.RegisterLectureRes;
 import org.springframework.stereotype.Component;
@@ -32,6 +34,15 @@ public class LectureMapper {
                         lecture.getInstructor()
                 ))
                 .collect(Collectors.toList());
+    }
+
+    public GetLectureWithScheduleRes toGetLectureWithScheduleRes(LectureInfo lectureInfo) {
+        return new GetLectureWithScheduleRes(
+                lectureInfo.lectureId(),
+                lectureInfo.title(),
+                lectureInfo.instructor(),
+                lectureInfo.scheduleInfos()
+        );
     }
 
 }

--- a/src/main/java/com/hhplus/clean/architecture/interfaces/LectureMapper.java
+++ b/src/main/java/com/hhplus/clean/architecture/interfaces/LectureMapper.java
@@ -2,7 +2,7 @@ package com.hhplus.clean.architecture.interfaces;
 
 import com.hhplus.clean.architecture.domain.lecture.Lecture;
 import com.hhplus.clean.architecture.domain.lecture.LectureRegistration;
-import com.hhplus.clean.architecture.domain.lecture.model.LectureInfo;
+import com.hhplus.clean.architecture.domain.lecture.model.LectureDetail;
 import com.hhplus.clean.architecture.interfaces.dto.GetLectureWithScheduleRes;
 import com.hhplus.clean.architecture.interfaces.dto.GetLecturesRes;
 import com.hhplus.clean.architecture.interfaces.dto.GetRegisteredLecturesRes;
@@ -37,17 +37,17 @@ public class LectureMapper {
                 .collect(Collectors.toList());
     }
 
-    public GetLectureWithScheduleRes toGetLectureWithScheduleRes(LectureInfo lectureInfo) {
+    public GetLectureWithScheduleRes toGetLectureWithScheduleRes(LectureDetail lectureDetail) {
         return new GetLectureWithScheduleRes(
-                lectureInfo.lectureId(),
-                lectureInfo.title(),
-                lectureInfo.instructor(),
-                lectureInfo.scheduleInfos()
+                lectureDetail.lectureId(),
+                lectureDetail.title(),
+                lectureDetail.instructor(),
+                lectureDetail.scheduleInfos()
         );
     }
 
-    public List<GetRegisteredLecturesRes> toGetRegisteredLectureRes(List<LectureInfo> lectureInfos) {
-        return lectureInfos.stream()
+    public List<GetRegisteredLecturesRes> toGetRegisteredLectureRes(List<LectureDetail> lectureDetails) {
+        return lectureDetails.stream()
                 .map(lectureInfo -> new GetRegisteredLecturesRes(
                         lectureInfo.lectureId(),
                         lectureInfo.title(),

--- a/src/main/java/com/hhplus/clean/architecture/interfaces/LectureMapper.java
+++ b/src/main/java/com/hhplus/clean/architecture/interfaces/LectureMapper.java
@@ -1,8 +1,8 @@
 package com.hhplus.clean.architecture.interfaces;
 
-import com.hhplus.clean.architecture.domain.lecture.Lecture;
-import com.hhplus.clean.architecture.domain.lecture.LectureRegistration;
 import com.hhplus.clean.architecture.domain.lecture.model.LectureDetail;
+import com.hhplus.clean.architecture.domain.lecture.model.LectureInfo;
+import com.hhplus.clean.architecture.domain.lecture.model.RegistrationInfo;
 import com.hhplus.clean.architecture.interfaces.dto.GetLectureWithScheduleRes;
 import com.hhplus.clean.architecture.interfaces.dto.GetLecturesRes;
 import com.hhplus.clean.architecture.interfaces.dto.GetRegisteredLecturesRes;
@@ -15,24 +15,24 @@ import java.util.stream.Collectors;
 @Component
 public class LectureMapper {
 
-    public RegisterLectureRes toRegisterLectureRes(LectureRegistration registration) {
+    public RegisterLectureRes toRegisterLectureRes(RegistrationInfo registration) {
         return new RegisterLectureRes(
-                registration.getId(),
-                registration.getUser().getId(),
-                registration.getUser().getName(),
-                registration.getLectureSchedule().getId(),
-                registration.getLectureSchedule().getLecture().getId(),
-                registration.getLectureSchedule().getLecture().getTitle(),
-                registration.getLectureSchedule().getScheduleDate()
+                registration.registerId(),
+                registration.userId(),
+                registration.userName(),
+                registration.scheduleId(),
+                registration.lectureId(),
+                registration.title(),
+                registration.scheduleDate()
         );
     }
 
-    public List<GetLecturesRes> toGetLecturesRes(List<Lecture> lectures) {
+    public List<GetLecturesRes> toGetLecturesRes(List<LectureInfo> lectures) {
         return lectures.stream()
                 .map(lecture -> new GetLecturesRes(
-                        lecture.getId(),
-                        lecture.getTitle(),
-                        lecture.getInstructor()
+                        lecture.lectureId(),
+                        lecture.title(),
+                        lecture.instructor()
                 ))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/hhplus/clean/architecture/interfaces/LectureMapper.java
+++ b/src/main/java/com/hhplus/clean/architecture/interfaces/LectureMapper.java
@@ -1,0 +1,22 @@
+package com.hhplus.clean.architecture.interfaces;
+
+import com.hhplus.clean.architecture.domain.lecture.LectureRegistration;
+import com.hhplus.clean.architecture.interfaces.dto.RegisterLectureRes;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LectureMapper {
+
+    public RegisterLectureRes toRegisterLectureRes(LectureRegistration registration) {
+        return new RegisterLectureRes(
+                registration.getId(),
+                registration.getUser().getId(),
+                registration.getUser().getName(),
+                registration.getLectureSchedule().getId(),
+                registration.getLectureSchedule().getLecture().getId(),
+                registration.getLectureSchedule().getLecture().getTitle(),
+                registration.getLectureSchedule().getScheduleDate()
+        );
+    }
+
+}

--- a/src/main/java/com/hhplus/clean/architecture/interfaces/dto/GetLectureWithScheduleRes.java
+++ b/src/main/java/com/hhplus/clean/architecture/interfaces/dto/GetLectureWithScheduleRes.java
@@ -1,0 +1,12 @@
+package com.hhplus.clean.architecture.interfaces.dto;
+
+import com.hhplus.clean.architecture.domain.lecture.model.ScheduleInfo;
+
+import java.util.List;
+
+public record GetLectureWithScheduleRes(
+        Long lectureId,
+        String title,
+        String instructor,
+        List<ScheduleInfo> scheduleInfos
+){ }

--- a/src/main/java/com/hhplus/clean/architecture/interfaces/dto/GetLecturesRes.java
+++ b/src/main/java/com/hhplus/clean/architecture/interfaces/dto/GetLecturesRes.java
@@ -1,0 +1,7 @@
+package com.hhplus.clean.architecture.interfaces.dto;
+
+public record GetLecturesRes (
+        Long lectureId,
+        String lectureTitle,
+        String Instructor
+) { }

--- a/src/main/java/com/hhplus/clean/architecture/interfaces/dto/GetRegisteredLecturesRes.java
+++ b/src/main/java/com/hhplus/clean/architecture/interfaces/dto/GetRegisteredLecturesRes.java
@@ -1,0 +1,12 @@
+package com.hhplus.clean.architecture.interfaces.dto;
+
+import com.hhplus.clean.architecture.domain.lecture.model.ScheduleInfo;
+
+import java.util.List;
+
+public record GetRegisteredLecturesRes(
+        Long lectureId,
+        String title,
+        String instructor,
+        List<ScheduleInfo> scheduleInfos
+) { }

--- a/src/main/java/com/hhplus/clean/architecture/interfaces/dto/RegisterLectureReq.java
+++ b/src/main/java/com/hhplus/clean/architecture/interfaces/dto/RegisterLectureReq.java
@@ -1,0 +1,4 @@
+package com.hhplus.clean.architecture.interfaces.dto;
+
+public record RegisterLectureReq(Long id) {
+}

--- a/src/main/java/com/hhplus/clean/architecture/interfaces/dto/RegisterLectureRes.java
+++ b/src/main/java/com/hhplus/clean/architecture/interfaces/dto/RegisterLectureRes.java
@@ -1,0 +1,13 @@
+package com.hhplus.clean.architecture.interfaces.dto;
+
+import java.time.LocalDate;
+
+public record RegisterLectureRes(
+        Long registrationId,
+        Long userId,
+        String userName,
+        Long scheduleId,
+        Long lectureId,
+        String lectureTitle,
+        LocalDate scheduleDate
+) {}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         show_sql: true

--- a/src/test/java/com/hhplus/clean/architecture/domain/lecture/LectureServiceTest.java
+++ b/src/test/java/com/hhplus/clean/architecture/domain/lecture/LectureServiceTest.java
@@ -175,4 +175,24 @@ class LectureServiceTest {
         assertEquals(3L,lectureInfo.scheduleInfos().get(0).scheduleId());
     }
 
+    @Test
+    @DisplayName("특강 신청 완료한 목록을 조회한다")
+    void shouldGetRegisteredLectureSchedulesByUserId(){
+        //given
+        Lecture lecture = new Lecture(1L, "Go Java!", "허 재");
+        Lecture lecture2 = new Lecture(2L, "Go python!", "토투");
+
+        when(lectureRepository.getRegistrationList(1L)).thenReturn(List.of(
+                LectureRegistration.create(user, new LectureSchedule(1L, lecture, 30, LocalDate.now())),
+                LectureRegistration.create(user, new LectureSchedule(2L, lecture2, 20, LocalDate.now()))
+        ));
+
+        //when
+        List<LectureInfo> lectureInfos = lectureService.getRegisteredLectures(user.getId());
+
+        //then
+        assertEquals(1L, lectureInfos.get(0).lectureId());
+        assertEquals("Go python!", lectureInfos.get(1).title());
+    }
+
 }

--- a/src/test/java/com/hhplus/clean/architecture/domain/lecture/LectureServiceTest.java
+++ b/src/test/java/com/hhplus/clean/architecture/domain/lecture/LectureServiceTest.java
@@ -190,8 +190,7 @@ class LectureServiceTest {
         List<LectureDetail> lectureDetails = lectureService.getRegisteredLectures(user.getId());
 
         //then
-        assertEquals(1L, lectureDetails.get(0).lectureId());
-        assertEquals("Go python!", lectureDetails.get(1).title());
+        assertEquals(2,lectureDetails.size());
     }
 
 }

--- a/src/test/java/com/hhplus/clean/architecture/domain/lecture/LectureServiceTest.java
+++ b/src/test/java/com/hhplus/clean/architecture/domain/lecture/LectureServiceTest.java
@@ -1,0 +1,112 @@
+package com.hhplus.clean.architecture.domain.lecture;
+
+import com.hhplus.clean.architecture.domain.error.BusinessException;
+import com.hhplus.clean.architecture.domain.user.User;
+import com.hhplus.clean.architecture.domain.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+
+import static com.hhplus.clean.architecture.domain.error.BusinessExceptionCode.DUPLICATE_ENROLLMENT;
+import static com.hhplus.clean.architecture.domain.error.BusinessExceptionCode.LECTURE_FULL;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LectureServiceTest {
+
+    @Mock
+    private LectureRepository lectureRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private LectureService lectureService;
+
+    private User user;
+    private Lecture lecture;
+
+    @BeforeEach
+    void setUp() {
+        user = new User(1L, "UserA");
+        when(userRepository.getUser(1L)).thenReturn(user);
+
+        lecture = new Lecture(1L, "Go Java!", "허 재");
+    }
+
+    @Test
+    @DisplayName("특강 신청이 성공적으로 이루어져야 한다")
+    void shouldRegisterLectureSuccessfully() {
+        //given
+        LectureSchedule schedule = new LectureSchedule(1L, lecture, 30, LocalDate.now());
+        when(lectureRepository.getLectureSchedule(1L)).thenReturn(schedule);
+        when(lectureRepository.isUserAlreadyRegistered(user, schedule)).thenReturn(false);
+
+        LectureRegistration registration = LectureRegistration.create(user, schedule);
+        when(lectureRepository.completeLectureRegistration(any(LectureRegistration.class))).thenReturn(registration);
+
+        //when
+        LectureRegistration savedRegistration = lectureService.registerLecture(1L, 1L);
+
+        //then
+        assertNotNull(savedRegistration);
+        assertEquals(user, savedRegistration.getUser());
+        assertEquals(schedule, savedRegistration.getLectureSchedule());
+    }
+
+
+    @Test
+    @DisplayName("이미 신청한 특강에 중복 신청 시 예외가 발생해야 한다")
+    void shouldThrowExceptionWhenUserIsAlreadyRegistered() {
+        // given
+        LectureSchedule schedule = new LectureSchedule(1L, lecture, 30, LocalDate.now());
+        when(lectureRepository.getLectureSchedule(1L)).thenReturn(schedule);
+        when(lectureRepository.isUserAlreadyRegistered(user, schedule)).thenReturn(true);
+
+        // when & then
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> lectureService.registerLecture(1L, 1L));
+
+        assertEquals(DUPLICATE_ENROLLMENT, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("수강 인원이 마감된 경우 예외가 발생해야 한다")
+    void shouldThrowExceptionWhenLectureIsFull() {
+        // given
+        LectureSchedule schedule = new LectureSchedule(1L, lecture, 0, LocalDate.now());
+        when(lectureRepository.getLectureSchedule(1L)).thenReturn(schedule);
+        when(lectureRepository.isUserAlreadyRegistered(user, schedule)).thenReturn(false);
+
+        // when & then
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> lectureService.registerLecture(1L, 1L));
+
+        assertEquals(LECTURE_FULL, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("특강 신청 후 수강인원이 정상적으로 감소해야 한다")
+    void shouldDecreaseLectureCapacity() {
+        // given
+        LectureSchedule schedule = new LectureSchedule(1L, lecture, 30, LocalDate.now());
+        when(lectureRepository.getLectureSchedule(1L)).thenReturn(schedule);
+        when(lectureRepository.isUserAlreadyRegistered(user, schedule)).thenReturn(false);
+
+        // when
+        LectureRegistration registration = lectureService.registerLecture(1L, 1L);
+
+        // then
+        assertEquals(29, schedule.getCapacity());
+    }
+
+
+}

--- a/src/test/java/com/hhplus/clean/architecture/domain/lecture/LectureServiceTest.java
+++ b/src/test/java/com/hhplus/clean/architecture/domain/lecture/LectureServiceTest.java
@@ -2,6 +2,8 @@ package com.hhplus.clean.architecture.domain.lecture;
 
 import com.hhplus.clean.architecture.domain.error.BusinessException;
 import com.hhplus.clean.architecture.domain.lecture.model.LectureDetail;
+import com.hhplus.clean.architecture.domain.lecture.model.LectureInfo;
+import com.hhplus.clean.architecture.domain.lecture.model.RegistrationInfo;
 import com.hhplus.clean.architecture.domain.user.User;
 import com.hhplus.clean.architecture.domain.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,7 +18,8 @@ import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.hhplus.clean.architecture.domain.error.BusinessExceptionCode.*;
+import static com.hhplus.clean.architecture.domain.error.BusinessExceptionCode.DUPLICATE_ENROLLMENT;
+import static com.hhplus.clean.architecture.domain.error.BusinessExceptionCode.LECTURE_FULL;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -55,12 +58,12 @@ class LectureServiceTest {
         when(lectureRepository.completeLectureRegistration(any(LectureRegistration.class))).thenReturn(registration);
 
         //when
-        LectureRegistration savedRegistration = lectureService.registerLecture(1L, 1L);
+        RegistrationInfo savedRegistration = lectureService.registerLecture(1L, 1L);
 
         //then
         assertNotNull(savedRegistration);
-        assertEquals(user, savedRegistration.getUser());
-        assertEquals(schedule, savedRegistration.getLectureSchedule());
+        assertEquals(1L, savedRegistration.userId());
+        assertEquals(1L, savedRegistration.scheduleId());
     }
 
 
@@ -106,7 +109,7 @@ class LectureServiceTest {
         when(lectureRepository.isUserAlreadyRegistered(user, schedule)).thenReturn(false);
 
         // when
-        LectureRegistration registration = lectureService.registerLecture(1L, 1L);
+        RegistrationInfo registration = lectureService.registerLecture(1L, 1L);
 
         // then
         assertEquals(29, schedule.getCapacity());
@@ -122,11 +125,11 @@ class LectureServiceTest {
         when(lectureRepository.getLectureList()).thenReturn(Arrays.asList(lecture1, lecture2, lecture3));
 
         //when
-        List<Lecture> lectures = lectureService.getLectureList();
+        List<LectureInfo> lectures = lectureService.getLectureList();
         //then
         assertNotNull(lectures);
         assertEquals(3, lectures.size());
-        assertEquals(3L, lectures.get(2).getId());
+        assertEquals(3L, lectures.get(2).lectureId());
     }
 
     @Test

--- a/src/test/java/com/hhplus/clean/architecture/domain/lecture/LectureServiceTest.java
+++ b/src/test/java/com/hhplus/clean/architecture/domain/lecture/LectureServiceTest.java
@@ -1,23 +1,19 @@
 package com.hhplus.clean.architecture.domain.lecture;
 
 import com.hhplus.clean.architecture.domain.error.BusinessException;
-import com.hhplus.clean.architecture.domain.lecture.model.LectureInfo;
+import com.hhplus.clean.architecture.domain.lecture.model.LectureDetail;
 import com.hhplus.clean.architecture.domain.user.User;
 import com.hhplus.clean.architecture.domain.user.UserRepository;
-import com.hhplus.clean.architecture.infrastructure.lecture.LectureJpaRepository;
-import com.hhplus.clean.architecture.infrastructure.lecture.LectureRepositoryImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import static com.hhplus.clean.architecture.domain.error.BusinessExceptionCode.*;
@@ -146,12 +142,12 @@ class LectureServiceTest {
         when(lectureRepository.getLectureScheduleList(1L)).thenReturn(Arrays.asList(schedule1, schedule2, schedule3));
 
         //when
-        LectureInfo lectureInfo = lectureService.getLectureWithSchedule(lecture.getId());
+        LectureDetail lectureDetail = lectureService.getLectureWithSchedule(lecture.getId());
 
         //then
-        assertEquals(3,lectureInfo.scheduleInfos().size());
-        assertEquals(30,lectureInfo.scheduleInfos().get(0).capacity());
-        assertEquals(LocalDate.of(2024, 10, 3),lectureInfo.scheduleInfos().get(2).scheduleDate());
+        assertEquals(3, lectureDetail.scheduleInfos().size());
+        assertEquals(30, lectureDetail.scheduleInfos().get(0).capacity());
+        assertEquals(LocalDate.of(2024, 10, 3), lectureDetail.scheduleInfos().get(2).scheduleDate());
 
     }
 
@@ -168,11 +164,11 @@ class LectureServiceTest {
         when(lectureRepository.getLectureScheduleList(1L)).thenReturn(Arrays.asList(schedule1, schedule2, schedule3));
 
         //when
-        LectureInfo lectureInfo = lectureService.getLectureWithSchedule(lecture.getId());
+        LectureDetail lectureDetail = lectureService.getLectureWithSchedule(lecture.getId());
 
         //then
-        assertEquals(1,lectureInfo.scheduleInfos().size());
-        assertEquals(3L,lectureInfo.scheduleInfos().get(0).scheduleId());
+        assertEquals(1, lectureDetail.scheduleInfos().size());
+        assertEquals(3L, lectureDetail.scheduleInfos().get(0).scheduleId());
     }
 
     @Test
@@ -188,11 +184,11 @@ class LectureServiceTest {
         ));
 
         //when
-        List<LectureInfo> lectureInfos = lectureService.getRegisteredLectures(user.getId());
+        List<LectureDetail> lectureDetails = lectureService.getRegisteredLectures(user.getId());
 
         //then
-        assertEquals(1L, lectureInfos.get(0).lectureId());
-        assertEquals("Go python!", lectureInfos.get(1).title());
+        assertEquals(1L, lectureDetails.get(0).lectureId());
+        assertEquals("Go python!", lectureDetails.get(1).title());
     }
 
 }

--- a/src/test/java/com/hhplus/clean/architecture/domain/lecture/LectureServiceTest.java
+++ b/src/test/java/com/hhplus/clean/architecture/domain/lecture/LectureServiceTest.java
@@ -3,18 +3,23 @@ package com.hhplus.clean.architecture.domain.lecture;
 import com.hhplus.clean.architecture.domain.error.BusinessException;
 import com.hhplus.clean.architecture.domain.user.User;
 import com.hhplus.clean.architecture.domain.user.UserRepository;
+import com.hhplus.clean.architecture.infrastructure.lecture.LectureJpaRepository;
+import com.hhplus.clean.architecture.infrastructure.lecture.LectureRepositoryImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
-import static com.hhplus.clean.architecture.domain.error.BusinessExceptionCode.DUPLICATE_ENROLLMENT;
-import static com.hhplus.clean.architecture.domain.error.BusinessExceptionCode.LECTURE_FULL;
+import static com.hhplus.clean.architecture.domain.error.BusinessExceptionCode.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -37,8 +42,6 @@ class LectureServiceTest {
     @BeforeEach
     void setUp() {
         user = new User(1L, "UserA");
-        when(userRepository.getUser(1L)).thenReturn(user);
-
         lecture = new Lecture(1L, "Go Java!", "허 재");
     }
 
@@ -46,6 +49,7 @@ class LectureServiceTest {
     @DisplayName("특강 신청이 성공적으로 이루어져야 한다")
     void shouldRegisterLectureSuccessfully() {
         //given
+        when(userRepository.getUser(1L)).thenReturn(user);
         LectureSchedule schedule = new LectureSchedule(1L, lecture, 30, LocalDate.now());
         when(lectureRepository.getLectureSchedule(1L)).thenReturn(schedule);
         when(lectureRepository.isUserAlreadyRegistered(user, schedule)).thenReturn(false);
@@ -67,6 +71,7 @@ class LectureServiceTest {
     @DisplayName("이미 신청한 특강에 중복 신청 시 예외가 발생해야 한다")
     void shouldThrowExceptionWhenUserIsAlreadyRegistered() {
         // given
+        when(userRepository.getUser(1L)).thenReturn(user);
         LectureSchedule schedule = new LectureSchedule(1L, lecture, 30, LocalDate.now());
         when(lectureRepository.getLectureSchedule(1L)).thenReturn(schedule);
         when(lectureRepository.isUserAlreadyRegistered(user, schedule)).thenReturn(true);
@@ -82,6 +87,7 @@ class LectureServiceTest {
     @DisplayName("수강 인원이 마감된 경우 예외가 발생해야 한다")
     void shouldThrowExceptionWhenLectureIsFull() {
         // given
+        when(userRepository.getUser(1L)).thenReturn(user);
         LectureSchedule schedule = new LectureSchedule(1L, lecture, 0, LocalDate.now());
         when(lectureRepository.getLectureSchedule(1L)).thenReturn(schedule);
         when(lectureRepository.isUserAlreadyRegistered(user, schedule)).thenReturn(false);
@@ -97,6 +103,7 @@ class LectureServiceTest {
     @DisplayName("특강 신청 후 수강인원이 정상적으로 감소해야 한다")
     void shouldDecreaseLectureCapacity() {
         // given
+        when(userRepository.getUser(1L)).thenReturn(user);
         LectureSchedule schedule = new LectureSchedule(1L, lecture, 30, LocalDate.now());
         when(lectureRepository.getLectureSchedule(1L)).thenReturn(schedule);
         when(lectureRepository.isUserAlreadyRegistered(user, schedule)).thenReturn(false);
@@ -108,5 +115,21 @@ class LectureServiceTest {
         assertEquals(29, schedule.getCapacity());
     }
 
+    @Test
+    @DisplayName("전체 특강목록을 조회한다")
+    void shouldGetLectureSuccessfully() {
+        //given
+        Lecture lecture1 = new Lecture(1L, "Go Java!", "허 재");
+        Lecture lecture2 = new Lecture(2L, "Go python!", "렌");
+        Lecture lecture3 = new Lecture(3L, "Go C#!", "로이");
+        when(lectureRepository.getLectureList()).thenReturn(Arrays.asList(lecture1, lecture2, lecture3));
+
+        //when
+        List<Lecture> lectures = lectureService.getLectureList();
+        //then
+        assertNotNull(lectures);
+        assertEquals(3, lectures.size());
+        assertEquals(3L, lectures.get(2).getId());
+    }
 
 }

--- a/src/test/java/com/hhplus/clean/architecture/domain/lecture/LectureServiceTest.java
+++ b/src/test/java/com/hhplus/clean/architecture/domain/lecture/LectureServiceTest.java
@@ -1,6 +1,7 @@
 package com.hhplus.clean.architecture.domain.lecture;
 
 import com.hhplus.clean.architecture.domain.error.BusinessException;
+import com.hhplus.clean.architecture.domain.lecture.model.LectureInfo;
 import com.hhplus.clean.architecture.domain.user.User;
 import com.hhplus.clean.architecture.domain.user.UserRepository;
 import com.hhplus.clean.architecture.infrastructure.lecture.LectureJpaRepository;
@@ -130,6 +131,48 @@ class LectureServiceTest {
         assertNotNull(lectures);
         assertEquals(3, lectures.size());
         assertEquals(3L, lectures.get(2).getId());
+    }
+
+    @Test
+    @DisplayName("수강 신청 가능한 날짜별 특강 목록을 조회한다.")
+    void shouldGetAvailableLectureSchedulesByLectureId(){
+        //given
+        Lecture lecture = new Lecture(1L, "Go Java!", "허 재");
+        when(lectureRepository.getLecture(1L)).thenReturn(lecture);
+
+        LectureSchedule schedule1 = new LectureSchedule(1L, lecture, 30, LocalDate.of(2024, 10, 1));
+        LectureSchedule schedule2 = new LectureSchedule(2L, lecture, 20, LocalDate.of(2024, 10, 2));
+        LectureSchedule schedule3 = new LectureSchedule(3L, lecture, 20, LocalDate.of(2024, 10, 3));
+        when(lectureRepository.getLectureScheduleList(1L)).thenReturn(Arrays.asList(schedule1, schedule2, schedule3));
+
+        //when
+        LectureInfo lectureInfo = lectureService.getLectureWithSchedule(lecture.getId());
+
+        //then
+        assertEquals(3,lectureInfo.scheduleInfos().size());
+        assertEquals(30,lectureInfo.scheduleInfos().get(0).capacity());
+        assertEquals(LocalDate.of(2024, 10, 3),lectureInfo.scheduleInfos().get(2).scheduleDate());
+
+    }
+
+    @Test
+    @DisplayName("특강 인원이 마감된 강의는 목록에서 조회되지 않는다.")
+    void shouldExcludeFullyBookedSchedulesFromLectureList(){
+        //given
+        Lecture lecture = new Lecture(1L, "Go Java!", "허 재");
+        when(lectureRepository.getLecture(1L)).thenReturn(lecture);
+
+        LectureSchedule schedule1 = new LectureSchedule(1L, lecture, 0, LocalDate.of(2024, 10, 1));
+        LectureSchedule schedule2 = new LectureSchedule(2L, lecture, 0, LocalDate.of(2024, 10, 2));
+        LectureSchedule schedule3 = new LectureSchedule(3L, lecture, 20, LocalDate.of(2024, 10, 3));
+        when(lectureRepository.getLectureScheduleList(1L)).thenReturn(Arrays.asList(schedule1, schedule2, schedule3));
+
+        //when
+        LectureInfo lectureInfo = lectureService.getLectureWithSchedule(lecture.getId());
+
+        //then
+        assertEquals(1,lectureInfo.scheduleInfos().size());
+        assertEquals(3L,lectureInfo.scheduleInfos().get(0).scheduleId());
     }
 
 }


### PR DESCRIPTION
## 구현사항

1️⃣ 특강 신청 [e70792e](https://github.com/syjeon0608/CleanArchitecture/pull/2/commits/e70792ec47fabff0921d06a61ced5666ba2efb26)

step 3,4 일부 요구사항이 default와 함께 작성되었습니다. 불편을 드려 죄송합니다.

- 특정 userId 로 특강을 신청
- 동일한 신청자는 동일한 강의에 대해서 한 번의 수강 신청만 성공(step4)
- 이미 신청자가 30명이 초과되면 이후 신청자는 요청을 실패(step3)

2️⃣ 특강 목록조회 [f53c242](https://github.com/syjeon0608/CleanArchitecture/pull/2/commits/f53c242fd1443531533c4720c47cf43d11f6a32b) [0fd8baf](https://github.com/syjeon0608/CleanArchitecture/pull/2/commits/0fd8baf3dcde472b9ca90a1e35e700db8dcdf148)

1. 서로다른 특강 목록 리스트 조회 (예: 자바특강, 파이썬특강, C#특강)
2. 날짜별로 현재 신청 가능한 특강 목록을 조회(예: { 자바특강 [10월 1일 , 10월 2일, 10월3일] , 파이썬특강 [10월 1일, 10월 2일, 10월 3일] }
- 특강의 정원은 30명으로 고정, 사용자는 각 특강에 신청하기전 신청 가능한 특강 목록을 조회

3️⃣ 특강 신청 완료 목록 조회 [ff9b5bd](https://github.com/syjeon0608/CleanArchitecture/pull/2/commits/ff9b5bddd531f4e9b4c505668e3d17c13d4a9b9f)

- 특정 userId 로 신청 완료된 특강 목록을 조회
- 각 항목은 특강 ID 및 이름, 강연자 정보를 담고 있음

## 리뷰포인트
-  POJO 사용: 인터페이스 계층에서 엔티티를 알지 않도록 하기 위해, 비즈니스계층에서 생성된 POJO를 프레젠테이션 계층으로 전달하도록 설계했습니다. 이를 통해 프레젠테이션 계층은 비즈니스 로직에서 필요한 데이터만 접근하게 되어, 엔티티를 직접적으로 노출하지 않도록 했습니다. 이로써 계층 간의 의존성을 최소화하고 각 계층의 역할을 명확히 분리하였습니다.
- Repository의 메서드 네이밍: JPA 기본 네이밍 컨벤션을 따르지 않고, 서비스 단에서 좀 더 직관적으로 메서드의 역할이 드러나도록 했습니다. 
- RepositoryImpl: repositoryImpl에서 데이터베이스 관련 예외 처리와 JPA를 직접 사용하여 비즈니스 로직을 처리하고 있습니다. 이를 통해 Repository는 JPA의 세부 구현을 감추면서도 필요한 데이터 접근과 예외 처리를 담당하게 했습니다. 이렇게 함으로써 비즈니스 로직과 데이터 접근 로직을 명확히 분리하여 계층 간 의존성을 줄이려했습니다.
- 테스트코드 : LectureService의 단위 테스트는 서비스 메서드가 의도대로 작동하는지 확인하는 데 중점을 두었습니다. User나 Lecture를 찾을 수 없을 때 발생하는 예외는 DB 조회와 관련이 있으므로, 이는 통합 테스트에서 다루는 것이 적절하다고 판단했습니다. 단위 테스트에서는 비즈니스 로직의 흐름과 결과가 예상대로 나오는지에 집중했습니다.
---
더 좋은 방식이나 개선점 있으면 조언 부탁드립니다!
리뷰 감사합니다!