### PR TITLE
Step4

### DIFF
--- a/src/test/java/com/hhplus/clean/architecture/domain/lecture/LectureServiceConcurrencyTest.java
+++ b/src/test/java/com/hhplus/clean/architecture/domain/lecture/LectureServiceConcurrencyTest.java
@@ -15,6 +15,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import static com.hhplus.clean.architecture.domain.error.BusinessExceptionCode.DUPLICATE_ENROLLMENT;
 import static com.hhplus.clean.architecture.domain.error.BusinessExceptionCode.LECTURE_NOT_FOUND;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -62,6 +63,50 @@ public class LectureServiceConcurrencyTest {
                 .orElseThrow(()-> new BusinessException(LECTURE_NOT_FOUND));
 
         assertEquals(0, updateLectureSchedule.getCapacity());
+    }
+
+    @Test
+    @DisplayName("동일한 유저가 동일한 특강을 5번 신청할 때 1번만 성공해야 한다.")
+    public void shouldAllowOnlyOneRegistrationPerUser() throws InterruptedException {
+        // given
+        User user = new User(1L, "User1");
+        userJpaRepository.save(user);
+
+        Lecture lecture = new Lecture(1L, "Go Java!", "허 재");
+        lectureJpaRepository.save(lecture);
+
+        LectureSchedule lectureSchedule = new LectureSchedule(1L, lecture, 30, LocalDate.now());
+        scheduleJpaRepository.save(lectureSchedule);
+
+
+        int numberOfThreads = 5;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+
+        int[] successfulRegistrations = {0};
+        int[] failedRegistrations = {0};
+
+        // when
+        for (int i = 0; i < numberOfThreads; i++) {
+            executorService.submit(() -> {
+                try {
+                    lectureService.registerLecture(user.getId(), lectureSchedule.getId());
+                    successfulRegistrations[0]++;
+                } catch (BusinessException e) {
+                    assertEquals(DUPLICATE_ENROLLMENT, e.getErrorCode());
+                    failedRegistrations[0]++;
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        // then
+        assertEquals(1, successfulRegistrations[0]);
+        assertEquals(4,failedRegistrations[0]);
     }
 
 

--- a/src/test/java/com/hhplus/clean/architecture/domain/lecture/LectureServiceConcurrencyTest.java
+++ b/src/test/java/com/hhplus/clean/architecture/domain/lecture/LectureServiceConcurrencyTest.java
@@ -41,6 +41,9 @@ public class LectureServiceConcurrencyTest {
 
         setupTestUsers(numberOfThreads);
 
+        int[] successfulRegistrations = {0};
+        int[] failedRegistrations = {0};
+
         ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
         CountDownLatch latch = new CountDownLatch(numberOfThreads);
 
@@ -50,8 +53,12 @@ public class LectureServiceConcurrencyTest {
             executorService.submit(() -> {
                 try {
                     lectureService.registerLecture(userId, lectureScheduleId);
-                } finally {
+                    successfulRegistrations[0]++;
+                } catch (Exception e){
+                    failedRegistrations[0]++;
+                }finally {
                     latch.countDown();
+
                 }
             });
         }
@@ -63,6 +70,8 @@ public class LectureServiceConcurrencyTest {
                 .orElseThrow(()-> new BusinessException(LECTURE_NOT_FOUND));
 
         assertEquals(0, updateLectureSchedule.getCapacity());
+        assertEquals(30, successfulRegistrations[0]);
+        assertEquals(10, failedRegistrations[0]);
     }
 
     @Test
@@ -106,7 +115,7 @@ public class LectureServiceConcurrencyTest {
 
         // then
         assertEquals(1, successfulRegistrations[0]);
-        assertEquals(4,failedRegistrations[0]);
+        assertEquals(4, failedRegistrations[0]);
     }
 
 


### PR DESCRIPTION
## 구현사항

1️⃣ 같은 유저의 같은 강의 신청(중복 신청) 동시성 제어

- step 3,4 일부 요구사항이 default와 함께 작성되었습니다. 불편을 드려 죄송합니다.
    - [defualt](https://github.com/syjeon0608/CleanArchitecture/pull/2/commits/e70792ec47fabff0921d06a61ced5666ba2efb26#r1786502903) LectureService에 중복 신청 금지 로직이 작성되었습니다.
- 현재 pr에서는 한 유저의 중복신청에 대한 동시성 제어 테스트 코드를 작성하였습니다.
- step3에서 lock을 걸어 현재 pr에서 추가 lock 관련 로직은 없습니다.

- ExecutorService와 CountDownLatch 사용. 5개의 쓰레드가 동시에 오는 상황을 가정. 테스트코드 작성